### PR TITLE
Remove from __future__ import statements - not required in Python3

### DIFF
--- a/carml/carml_check_pypi.py
+++ b/carml/carml_check_pypi.py
@@ -1,8 +1,6 @@
 # check Python Package Index (PyPI) over 3 different circuits and
 # compare sha256 hashes. suitable for use in requirements.txt with
 # "twine"
-from __future__ import print_function
-
 from zope.interface import implementer
 from twisted.python import usage
 from twisted.plugin import IPlugin

--- a/carml/carml_circ.py
+++ b/carml/carml_circ.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import datetime
 import functools

--- a/carml/carml_cmd.py
+++ b/carml/carml_cmd.py
@@ -1,9 +1,6 @@
 #
 # FIXME: better name? "the command called cmd" is pretty weird
 #
-
-from __future__ import print_function
-
 import os
 import sys
 import functools

--- a/carml/carml_copybin.py
+++ b/carml/carml_copybin.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import time
 import functools

--- a/carml/carml_events.py
+++ b/carml/carml_events.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import time

--- a/carml/carml_graph.py
+++ b/carml/carml_graph.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import functools

--- a/carml/carml_monitor.py
+++ b/carml/carml_monitor.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-
-
 import os
 import sys
 import functools

--- a/carml/carml_newid.py
+++ b/carml/carml_newid.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import functools
 

--- a/carml/carml_onion.py
+++ b/carml/carml_onion.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import time
 import json

--- a/carml/carml_pastebin.py
+++ b/carml/carml_pastebin.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import time
 import functools

--- a/carml/carml_readme.py
+++ b/carml/carml_readme.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import pkg_resources
 import click
 

--- a/carml/carml_relay.py
+++ b/carml/carml_relay.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import datetime
 import functools

--- a/carml/carml_stream.py
+++ b/carml/carml_stream.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import functools

--- a/carml/carml_tbb.py
+++ b/carml/carml_tbb.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import platform
 import os

--- a/carml/carml_tmux.py
+++ b/carml/carml_tmux.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import time
 import functools

--- a/carml/cli.py
+++ b/carml/cli.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import sys
 
 from twisted.internet import defer, task

--- a/carml/command/downloadbundle.py
+++ b/carml/command/downloadbundle.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from StringIO import StringIO
 import json
 import platform

--- a/carml/util.py
+++ b/carml/util.py
@@ -5,9 +5,6 @@ Probably some of these could be replaced by a library or two,
 especially the progress-bar hackery. The colour stuff is also a little
 wonky.
 '''
-
-from __future__ import print_function
-
 import datetime
 import functools
 from six import unichr


### PR DESCRIPTION
Sun Dec 16 21:45:22 GMT 2018

From comments on commit 6f5f3a5